### PR TITLE
Reconnecting players

### DIFF
--- a/game-logic/GameManager.ts
+++ b/game-logic/GameManager.ts
@@ -141,8 +141,9 @@ export class GameManager {
 	private handlePlayerJoined(playerName: string, id: string): void {
 		const isRejoining = this.game.archivedPlayers.some((player) => player.id === id)
 		if (isRejoining) {
+			// promote the player out of the archive, set their ready state to false
 			const player = this.game.archivedPlayers.find((player) => player.id === id)!
-			const updatedPlayers = [...this.game.players, player]
+			const updatedPlayers = [...this.game.players, { ...player, ready: false }]
 			const filteredArchivedPlayers = this.game.archivedPlayers.filter((player) => player.id !== id)
 			this.game = {
 				...this.game,

--- a/game-logic/GameManager.ts
+++ b/game-logic/GameManager.ts
@@ -139,10 +139,20 @@ export class GameManager {
 		'Jr',
 	]
 	private handlePlayerJoined(playerName: string, id: string): void {
+		const isRejoining = this.game.archivedPlayers.some((player) => player.id === id)
+		if (isRejoining) {
+			const player = this.game.archivedPlayers.find((player) => player.id === id)!
+			const updatedPlayers = [...this.game.players, player]
+			const filteredArchivedPlayers = this.game.archivedPlayers.filter((player) => player.id !== id)
+			this.game = {
+				...this.game,
+				players: updatedPlayers,
+				archivedPlayers: filteredArchivedPlayers,
+			}
+			return
+		}
 		const sameName = this.game.players.some((player) => player.name === playerName)
-		const isWaiting = this.game.state === 'waiting'
 		let nameToUse = playerName
-		if (!isWaiting) return
 
 		if (sameName) {
 			// does this player have the same id?, if so, do nothing

--- a/game-logic/GameManager.ts
+++ b/game-logic/GameManager.ts
@@ -169,11 +169,14 @@ export class GameManager {
 	}
 
 	private handlePlayerLeft(id: string): void {
+		const leavingPlayer = this.game.players.find((player) => player.id === id)!
 		const updatedPlayers = this.game.players.filter((player) => player.id !== id)
+		const updatedArchivedPlayers = [...this.game.archivedPlayers, leavingPlayer]
 
 		if (updatedPlayers.length < GameManager.MIN_PLAYERS) {
 			this.game = {
 				...this.game,
+				archivedPlayers: updatedArchivedPlayers,
 				state: 'waiting',
 				players: updatedPlayers.map((player) => ({
 					...player,
@@ -182,7 +185,8 @@ export class GameManager {
 			}
 			return
 		}
-		this.game = { ...this.game, players: updatedPlayers }
+
+		this.game = { ...this.game, players: updatedPlayers, archivedPlayers: updatedArchivedPlayers }
 	}
 
 	private handleToggleReady(id: string): void {

--- a/game-logic/GameManager.ts
+++ b/game-logic/GameManager.ts
@@ -52,6 +52,7 @@ export class GameManager {
 			],
 			prevAnswers: [],
 			category: formInfo.category,
+			archivedPlayers: [],
 		}
 
 		return new GameManager(initialGame)

--- a/game-logic/types.ts
+++ b/game-logic/types.ts
@@ -64,6 +64,7 @@ export interface GameInfo {
 	answer: Answer
 	prevAnswers: Answer[]
 	category: Category
+	archivedPlayers: Player[]
 }
 
 export const filmAnswers = [

--- a/party/index.ts
+++ b/party/index.ts
@@ -68,7 +68,7 @@ export default class Server implements Party.Server {
 		console.log('player left', connection.id)
 		if (!this.gameManager) return
 		// wait for 5 minutes then check if player rejoined
-		const timeout = 1000
+		const timeout = 1000 * 60 * 5
 		setTimeout(() => {
 			const connectionsArray = []
 			for (const c of this.party.getConnections()) {

--- a/party/index.ts
+++ b/party/index.ts
@@ -50,7 +50,8 @@ export default class Server implements Party.Server {
 	async onClose(connection: Party.Connection) {
 		console.log('player left', connection.id)
 		if (!this.gameManager) return
-		// wait for 20 seconds then check if player rejoined
+		// wait for 5 minutes then check if player rejoined
+		const timeout = 1000 * 60 * 5
 		setTimeout(() => {
 			const connectionsArray = []
 			for (const c of this.party.getConnections()) {
@@ -64,7 +65,7 @@ export default class Server implements Party.Server {
 				})
 				this.party.broadcast(JSON.stringify(this.gameManager?.getState()))
 			}
-		}, 20000)
+		}, timeout)
 	}
 
 	async onMessage(message: string) {

--- a/party/index.ts
+++ b/party/index.ts
@@ -44,6 +44,14 @@ export default class Server implements Party.Server {
 
 	async onConnect(connection: Party.Connection) {
 		if (!this.gameManager) return
+		// if the player is archived, they are rejoining the game
+		const player = this.gameManager.getState().archivedPlayers.find((p) => p.id === connection.id)
+		if (player) {
+			this.gameManager.handleAction({
+				type: 'player-joined',
+				payload: { id: player.id, name: player.name },
+			})
+		}
 		connection.send(JSON.stringify(this.gameManager.getState()))
 	}
 

--- a/src/app/components/ResultsScreen.tsx
+++ b/src/app/components/ResultsScreen.tsx
@@ -48,9 +48,9 @@ function MessagePanel({
 				)
 			) : avoidedDetection ? (
 				votedForImposter ? (
-					<RedMessage message={'They got away! The imposter was ' + imposter.name + '.'} />
-				) : (
 					<YellowMessage message={'You voted for the imposter, but they got away!'} />
+				) : (
+					<RedMessage message={'They got away! The imposter was ' + imposter.name + '.'} />
 				)
 			) : guessedCorrectly ? (
 				<YellowMessage message="You got the imposter, but they guessed the answer!" />

--- a/src/app/components/ResultsScreen.tsx
+++ b/src/app/components/ResultsScreen.tsx
@@ -163,7 +163,7 @@ function MainSection({ player, scoreDifference }: { player: Player; scoreDiffere
 
 function PlayerVotes({ player }: { player: Player }) {
 	const { gameState } = useActiveGame()
-	console.log(gameState.players)
+
 	return (
 		<div className="bg-gray-50 px-4 py-3 border-t border-gray-100">
 			<div className="flex items-center gap-2">

--- a/src/app/hooks/useGameState.tsx
+++ b/src/app/hooks/useGameState.tsx
@@ -28,7 +28,7 @@ export function GameProvider({
 		if (gameState.state === 'loading') return null
 		return gameState.players.find((player) => player.id === playerId) ?? null
 	}, [gameState, playerId])
-
+	console.log('playerid:', playerId)
 	const socket = usePartySocket({
 		host: PARTYKIT_HOST,
 		room: roomId,

--- a/src/app/hooks/useGameState.tsx
+++ b/src/app/hooks/useGameState.tsx
@@ -20,7 +20,7 @@ export function GameProvider({
 }: {
 	children: React.ReactNode
 	playerId: string
-	roomId: string
+roomId: string
 }) {
 	const [gameState, setGameState] = useState<GameState>({ state: 'loading' })
 

--- a/src/app/hooks/usePlayerId.tsx
+++ b/src/app/hooks/usePlayerId.tsx
@@ -8,14 +8,14 @@ export function usePlayerId() {
 
 	useEffect(() => {
 		// Check for existing player ID in sessionStorage
-		const existingPlayerId = sessionStorage.getItem(PLAYER_ID_KEY)
+		const existingPlayerId = localStorage.getItem(PLAYER_ID_KEY)
 
 		if (existingPlayerId) {
 			setPlayerId(existingPlayerId)
 		} else {
 			// Generate new player ID if none exists
 			const newPlayerId = uuidv4()
-			sessionStorage.setItem(PLAYER_ID_KEY, newPlayerId)
+			localStorage.setItem(PLAYER_ID_KEY, newPlayerId)
 			setPlayerId(newPlayerId)
 		}
 	}, [])

--- a/tests/game-logic.test.ts
+++ b/tests/game-logic.test.ts
@@ -182,8 +182,18 @@ describe('When in the waiting state...', () => {
 		// All players should be unready
 		expect(gameState.players.every((player) => !player.ready)).toBeTruthy()
 		// Player 3 should be archived
-		console.log(gameState.archivedPlayers)
 		expect(gameState.archivedPlayers.some((player) => player.id === PLAYER_3)).toBeTruthy()
+
+		// rejoin as player 3
+		gameManager.handleAction({
+			type: 'player-joined',
+			payload: { id: PLAYER_3, name: PLAYER_3 },
+		})
+
+		// archive should be empty
+		expect(gameManager.getState().archivedPlayers.length).toBe(0)
+		// player should be added back
+		expect(gameManager.getState().players.length).toBe(3)
 	})
 })
 

--- a/tests/game-logic.test.ts
+++ b/tests/game-logic.test.ts
@@ -181,6 +181,9 @@ describe('When in the waiting state...', () => {
 		expect(gameState.players.length).toBe(2)
 		// All players should be unready
 		expect(gameState.players.every((player) => !player.ready)).toBeTruthy()
+		// Player 3 should be archived
+		console.log(gameState.archivedPlayers)
+		expect(gameState.archivedPlayers.some((player) => player.id === PLAYER_3)).toBeTruthy()
 	})
 })
 

--- a/tests/game-logic.test.ts
+++ b/tests/game-logic.test.ts
@@ -405,4 +405,5 @@ const createTestGameState = (state: 'playing' | 'voting' | 'results'): GameInfo 
 	],
 	prevAnswers: [],
 	category: CATEGORY,
+	archivedPlayers: [],
 })


### PR DESCRIPTION
Before when a player disconnected, there was a not-very-generous timeout in the partykit server, after which the player was kicked from the game. Trying to rejoin the game after 20 seconds led to an error, as the application couldn't find the player's id in the array of players.

## Changes

1. **Longer timeout :** The server now waits 5 minutes before kicking disconnected players. It's likely that a round of play will last about this long.
2. **Archived players arr :** This PR introduces an array of archived players. Now when a player leaves, they are put in the archive, if they rejoin they are promoted out of the archive.