### PR TITLE
Improve voting screen user flow

### DIFF
--- a/src/app/components/AnswerGrid.tsx
+++ b/src/app/components/AnswerGrid.tsx
@@ -17,9 +17,9 @@ export function AnswerGrid({
 				hasButtons ? (
 					<Button
 						key={answer}
-						className="text-center"
+						className={localPlayer.guess === answer ? '!bg-green-100' : ''}
 						onClick={onClick ? () => onClick(answer) : undefined}
-						variant={localPlayer.guess === answer ? 'primary' : 'secondary'}
+						variant="answerGrid"
 					>
 						{answer}
 					</Button>

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import { ReactNode } from 'react'
 
-type ButtonVariant = 'primary' | 'secondary' | 'disabled'
+type ButtonVariant = 'primary' | 'secondary' | 'disabled' | 'answerGrid'
 type ButtonBaseProps = {
 	children: ReactNode
 	className?: string
@@ -31,6 +31,7 @@ const baseStyles = 'px-4 py-4 rounded-md font-medium transition-colors'
 const variantStyles: Record<ButtonVariant, string> = {
 	primary: 'bg-blue-500 text-white hover:bg-blue-900',
 	secondary: 'bg-gray-300 text-gray-800 hover:bg-gray-400',
+	answerGrid: 'text-center bg-gray-100 hover:bg-gray-200',
 	disabled: 'bg-gray-200 text-gray-400',
 }
 

--- a/src/app/components/ReadyBtnWithPresence.tsx
+++ b/src/app/components/ReadyBtnWithPresence.tsx
@@ -23,10 +23,8 @@ export function ReadyBtnWithPresence({ text }: { text: string }) {
 					</Button>
 				</div>
 			</div>
-			<span className="flex w-full items-center justify-center gap-1 mt-2 p-3 bg-gray-100 border rounded-b-lg">
-				<p className="text-nowrap text-xs text-gray-500">Players ready:</p>
-				<Presence />
-			</span>
+
+			<Presence />
 		</Panel>
 	)
 }
@@ -34,22 +32,26 @@ export function ReadyBtnWithPresence({ text }: { text: string }) {
 export function Presence() {
 	const { gameState } = useActiveGame()
 	return (
-		<div className="flex self-start w-full overflow-hidden">
-			{gameState.players
-				.sort((a, b) => {
-					if (a.ready && !b.ready) return -1
-					if (!a.ready && b.ready) return 1
-					return 0
-				})
-				.map((player, i) => (
-					<div
-						style={{ transform: `translateX(-${i * 8}px)`, zIndex: gameState.players.length - i }}
-						key={player.name}
-						className="flex items-center gap-2"
-					>
-						<PlayerInitialsIcon className="!w-5 !h-5 text-xs" showReady player={player} />
-					</div>
-				))}
+		<div className="flex w-full items-center justify-center gap-1 mt-2 p-3 bg-gray-100 border rounded-b-lg">
+			<p className="text-nowrap text-xs text-gray-500">Players ready:</p>
+
+			<div className="flex self-start w-full overflow-hidden">
+				{gameState.players
+					.sort((a, b) => {
+						if (a.ready && !b.ready) return -1
+						if (!a.ready && b.ready) return 1
+						return 0
+					})
+					.map((player, i) => (
+						<div
+							style={{ transform: `translateX(-${i * 8}px)`, zIndex: gameState.players.length - i }}
+							key={player.name}
+							className="flex items-center gap-2"
+						>
+							<PlayerInitialsIcon className="!w-5 !h-5 text-xs" showReady player={player} />
+						</div>
+					))}
+			</div>
 		</div>
 	)
 }

--- a/src/app/components/VotingScreen.tsx
+++ b/src/app/components/VotingScreen.tsx
@@ -1,15 +1,22 @@
+import { useState } from 'react'
 import { Answer, Player } from '../../../game-logic/types'
 import { useActiveGame, useLocalPlayer } from '../hooks/useGameState'
 import { AnswerGrid } from './AnswerGrid'
 import { Button } from './Button'
 import { Panel } from './Panel'
 import { PlayerInitialsIcon } from './PlayerInitialsIcon'
+import { Presence } from './ReadyBtnWithPresence'
 
 export function VotingScreen() {
+	const localPlayer = useLocalPlayer()
+	const [hasChosenAnswer, setHasChosenAnswer] = useState(false)
 	return (
 		<>
-			<ChooseAnswer />
-			<VotePanel />
+			{localPlayer.imposter && !hasChosenAnswer ? (
+				<ChooseAnswer onChoose={() => setHasChosenAnswer(true)} />
+			) : (
+				<VotePanel />
+			)}
 		</>
 	)
 }
@@ -29,11 +36,12 @@ function VotePanel() {
 						))}
 				</ul>
 			</div>
+			<Presence />
 		</Panel>
 	)
 }
 
-function ChooseAnswer() {
+function ChooseAnswer({ onChoose }: { onChoose: () => void }) {
 	const { dispatch } = useActiveGame()
 	const localPlayer = useLocalPlayer()
 
@@ -42,11 +50,19 @@ function ChooseAnswer() {
 	}
 	if (!localPlayer.imposter) return null
 	return (
-		<Panel>
+		<Panel variant="column">
 			<h2 className="text-md mb-4 text-start">Choose an answer:</h2>
 			<ul className="space-y-4">
 				<AnswerGrid hasButtons onClick={handleGuess} />
 			</ul>
+			<Button
+				className="w-full"
+				disabled={localPlayer.guess === undefined}
+				onClick={onChoose}
+				variant="primary"
+			>
+				Confirm
+			</Button>
 		</Panel>
 	)
 }

--- a/tests/e2e/e2e.spec.ts
+++ b/tests/e2e/e2e.spec.ts
@@ -122,9 +122,11 @@ test.describe('The Imposter Game', () => {
 				await player.gamePage.readyToVoteButton.click()
 			}
 
-			// Verify vote panel is visible for all players
+			// Verify we're on the voting screen
 			for (const player of playerArr) {
-				await expect(player.gamePage.votePanel).toBeVisible()
+				if (await player.gamePage.votePanel.isHidden()) {
+					await expect(player.gamePage.answerGrid).toBeVisible()
+				}
 			}
 
 			// All players vote for the next player in the list
@@ -134,7 +136,19 @@ test.describe('The Imposter Game', () => {
 
 				// if the player is the imposter, they have to guess the answer
 				if (await player.gamePage.answerGrid.isVisible()) {
-					await player.gamePage.answerGrid.getByRole('button').getByText('Titanic').click()
+					const answerButton = player.gamePage.answerGrid.getByRole('button').getByText('Titanic')
+
+					// Verify the initial color is gray
+					await expect(answerButton).toHaveCSS('background-color', 'rgb(243, 244, 246)')
+
+					// Click the answer
+					await answerButton.click()
+
+					// Verify the color changes to green
+					await expect(answerButton).toHaveCSS('background-color', 'rgb(220, 252, 231)')
+
+					// Click the confirm button
+					await player.gamePage.confirmButtonVotingScreen.click()
 				}
 
 				await voteForPlayer(player, playerToVoteFor)
@@ -181,7 +195,11 @@ test.describe('The Imposter Game', () => {
 				await player.gamePage.readyToVoteButton.click()
 			}
 			for (const player of playerArr) {
-				await expect(player.gamePage.votePanel).toBeVisible()
+				if (await player.gamePage.votePanel.isHidden()) {
+					await expect(player.gamePage.answerGrid).toBeVisible()
+				} else {
+					expect(player.gamePage.votePanel).toBeVisible()
+				}
 			}
 			// one player closes their browser
 			await player1.page.close()

--- a/tests/e2e/fixtures/GamePage.ts
+++ b/tests/e2e/fixtures/GamePage.ts
@@ -15,6 +15,7 @@ export class GamePage {
 	public readonly playerScoreItem: Locator
 	public readonly imposterBadge: Locator
 	public readonly infoBarRound: Locator
+	public readonly confirmButtonVotingScreen: Locator
 	constructor(private readonly page: Page) {
 		this.readyButton = page.getByRole('button').getByText('Ready')
 		this.readyButtonDisabled = page.getByRole('button').getByText('...')
@@ -30,6 +31,7 @@ export class GamePage {
 		this.playerScoreItem = page.getByTestId('player-score-item')
 		this.imposterBadge = page.getByTestId('imposter-badge').getByText('IMPOSTER')
 		this.infoBarRound = page.getByTestId('info-bar-round')
+		this.confirmButtonVotingScreen = page.getByRole('button').getByText('Confirm')
 	}
 
 	async getNumberOfWaitingPlayers() {


### PR DESCRIPTION
## Summary

Playtesting revealed many people breaking from the intended user journey on the voting screen because imposters were unaware they needed to also submit a guess. This PR breaks imposter voting and guessing stages into steps, requiring one is done before the other.

## Changes

Added confirmation step for imposter's answer selection
Changed selected answers to highlight in green instead of blue
Created a new answerGrid button variant for consistent styling
Refactored Presence component for better reusability
Updated E2E tests to match new flow

These improvements provide a more intuitive player experience with clearer visual feedback.